### PR TITLE
build: use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3.2.0
         with:
-          app-id: ${{secrets.GH_APP_ID}}
+          client-id: ${{secrets.GH_APP_CLIENT_ID}}
           private-key: ${{secrets.GH_APP_PRIVATE_KEY}}
       - name: Release
         run: npx semantic-release

--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3.2.0
         with:
-          app-id: ${{secrets.GH_APP_ID}}
+          client-id: ${{secrets.GH_APP_CLIENT_ID}}
           private-key: ${{secrets.GH_APP_PRIVATE_KEY}}
       - name: Generate user info
         id: user-info

--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -37,7 +37,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3.2.0
         with:
-          app-id: ${{secrets.GH_APP_ID}}
+          client-id: ${{secrets.GH_APP_CLIENT_ID}}
           private-key: ${{secrets.GH_APP_PRIVATE_KEY}}
       - name: Generate user info
         id: user-info


### PR DESCRIPTION
Updates uses of actions/create-github-app-token to use the client-id parameter and GH_APP_CLIENT_ID secret instead of app-id and GH_APP_ID.