### PR TITLE
chore: harden .npmrc with ignore-scripts and engine-strict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+ignore-scripts=true


### PR DESCRIPTION
Ensures .npmrc sets ignore-scripts=true and engine-strict=true.